### PR TITLE
Fixes #6391 duplicate of #6318

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-edit-folder/dnn-rm-edit-folder.tsx
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-rm-edit-folder/dnn-rm-edit-folder.tsx
@@ -134,13 +134,13 @@ export class DnnRmEditFolder {
   private handlePermissionsChanged(newPermissions: IPermissions): void {
     // Get previous role permissions and adjust related permissions
     newPermissions.rolePermissions.forEach(rolePermission => {
-      const previousPermissions = this.lastPermissions?.rolePermissions?.find(p => p.roleId === rolePermission.roleId).permissions ?? [];
+      const previousPermissions = this.lastPermissions?.rolePermissions?.find(p => p.roleId === rolePermission.roleId)?.permissions ?? [];
       this.adjustRelatedPermissions(rolePermission, previousPermissions);
     });
   
     // Get previous user permissions and adjust related permissions
     newPermissions.userPermissions.forEach(userPermission => {
-      const previousPermissions = this.lastPermissions?.userPermissions?.find(p => p.userId === userPermission.userId).permissions ?? [];
+      const previousPermissions = this.lastPermissions?.userPermissions?.find(p => p.userId === userPermission.userId)?.permissions ?? [];
       this.adjustRelatedPermissions(userPermission, previousPermissions);
     });
   


### PR DESCRIPTION
Solve permission problems as reported in
#6391 and #6318






## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
 
this.lastPermissions?.rolePermissions?.**find**(p => p.roleId === rolePermission.roleId).permissions

the **find** returns an undefined for newly added roles (and users) to the permission grid, therefore the .permissions crashes and subsequent failures follow.

